### PR TITLE
Fix issue with dropdown not setting correct value

### DIFF
--- a/pods-frontier-auto-template.php
+++ b/pods-frontier-auto-template.php
@@ -270,8 +270,8 @@ class Pods_PFAT {
 
 				}
 
-				$options[ 'pods-pfat' ][ 'pfat_archive' ][ 'data' ] = $this->get_template_titles();
-				$options[ 'pods-pfat' ][ 'pfat_single' ][ 'data' ] = $this->get_template_titles();
+				$options[ 'pods-pfat' ][ 'pfat_archive' ][ 'data' ] = array_combine( $this->get_template_titles(), $this->get_template_titles() );
+				$options[ 'pods-pfat' ][ 'pfat_single' ][ 'data' ] = array_combine( $this->get_template_titles(), $this->get_template_titles() );
 			}
 
 			//Add data to $pick for template location
@@ -521,5 +521,5 @@ function pfat_admin_notice_pods_min_version_fail() {
 		} //endif version compare
 
 	} //endif Pods is not active
-	
+
 }


### PR DESCRIPTION
Currently, if you set `define( 'PFAT_TEMPLATE_SELECT_DROPDOWN', true );`, and then save your dropdown selection, no template is selected. This is because the value property is not set on the option, so only an integer gets saved, instead of the template name. And _that_ is due to using a keyless array to set the dropdown options.

This sets the actual value of a given option to also match the text and fixes the issue. The alternative would be to set the value as the template ID, but we'd also need to add a function to translate that into the name eventually, as that's how the data is designed to be stored (as a string). 